### PR TITLE
Override toString() to return unsigned value

### DIFF
--- a/src/main/kotlin/unsigned/Ubyte.kt
+++ b/src/main/kotlin/unsigned/Ubyte.kt
@@ -94,4 +94,6 @@ data class Ubyte(var v: Byte = 0) : Number() {
     operator fun compareTo(b: Ubyte) = toInt() compareUnsigned b.toInt()
     operator fun compareTo(b: Byte) = toInt() compareUnsigned b.toUInt()
     operator fun compareTo(b: Int) = toInt() compareUnsigned b
+
+    override fun toString() = toInt().toString()
 }

--- a/src/main/kotlin/unsigned/Uint.kt
+++ b/src/main/kotlin/unsigned/Uint.kt
@@ -77,5 +77,7 @@ data class Uint(var v: Int = 0) : Number() {
     operator fun compareTo(b: Uint) = v compareUnsigned b.toInt()
     operator fun compareTo(b: Int) = v compareUnsigned b
 
+    override fun toString() = toLong().toString()
+
     // TODO long?
 }

--- a/src/main/kotlin/unsigned/Ulong.kt
+++ b/src/main/kotlin/unsigned/Ulong.kt
@@ -73,6 +73,8 @@ data class Ulong(var v: Long = 0) : Number(), Comparable<Ulong> {
 
     // TODO others
 
+    override fun toString() = toBigInt().toString()
+
     operator fun rangeTo(b: Ulong) = UlongRange(this, b)
 
     class UlongRange(override val start: Ulong, override val endInclusive: Ulong) : ClosedRange<Ulong>, Iterable<Ulong> {

--- a/src/main/kotlin/unsigned/Ushort.kt
+++ b/src/main/kotlin/unsigned/Ushort.kt
@@ -91,4 +91,6 @@ data class Ushort(var v: Short = 0) : Number() {
     operator fun compareTo(b: Ushort) = toInt() compareUnsigned b.toInt()
     operator fun compareTo(b: Short) = toInt() compareUnsigned b.toUInt()
     operator fun compareTo(b: Int) = toInt() compareUnsigned b
+
+    override fun toString() = toInt().toString()
 }

--- a/src/test/kotlin/unsigned/test.kt
+++ b/src/test/kotlin/unsigned/test.kt
@@ -567,5 +567,16 @@ class Unsigned : StringSpec() {
             ((65_500 ucmp Ushort(65_499)) > 0) shouldBe true
             (65_500 ucmp Ushort(65_500)) shouldBe 0
         }
+
+        "string format" {
+            Ubyte(0xff).v.toString() shouldBe "-1"
+            Ubyte(0xff).toString() shouldBe "255"
+            Ushort(0xffff).v.toString() shouldBe "-1"
+            Ushort(0xffff).toString() shouldBe "65535"
+            Uint(0xffff_ffff).v.toString() shouldBe "-1"
+            Uint(0xffff_ffff).toString() shouldBe "4294967295"
+            Ulong(Ulong.MAX_VALUE).v.toString() shouldBe "-1"
+            Ulong(Ulong.MAX_VALUE).toString() shouldBe "18446744073709551615"
+        }
     }
 }


### PR DESCRIPTION
It is useful to see correct unsigned value in toString() instead of default `U<type>(v=<signed value>)`